### PR TITLE
[FEAT] Added indent size for improved readability on github.com

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ root = true
 
 [*]
 indent_style = tab
+indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
Specified the indent size in the editorconfig file so source code is easier to read on GitHub.com. Without this GH uses 8 spaces as default.